### PR TITLE
Clear buffers to remove garbage

### DIFF
--- a/PluginProcessor.cpp
+++ b/PluginProcessor.cpp
@@ -167,8 +167,11 @@ bool EffectsPluginProcessor::isBusesLayoutSupported (const AudioProcessor::Buses
 
 void EffectsPluginProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& /* midiMessages */)
 {
-    if (runtime == nullptr)
+    if (runtime == nullptr) {
+        // Clear the buffers from any garbage
+        for (auto i = 0; i < buffer.getNumChannels(); ++i) buffer.clear(i, 0, buffer.getNumSamples());
         return;
+    }
 
     // Copy the input so that our input and output buffers are distinct
     scratchBuffer.makeCopyOf(buffer, true);


### PR DESCRIPTION
This fixes leftover garbage in the audio buffer before runtime initialization
<img width="126" alt="Screenshot 2023-07-05 at 22 59 00" src="https://github.com/elemaudio/effects-plugin/assets/536859/d4eb9ff3-ca09-4a66-b484-a773d5613a52">
