### PR TITLE
Improve handling of state variables

### DIFF
--- a/PluginProcessor.cpp
+++ b/PluginProcessor.cpp
@@ -340,8 +340,12 @@ void EffectsPluginProcessor::setStateInformation (const void* data, int sizeInBy
     try {
         auto str = std::string(static_cast<const char*>(data), sizeInBytes);
         auto parsed = elem::js::parseJSON(str);
-
-        state = parsed.getObject();
+        auto o = parsed.getObject();
+        for (auto  &i: o) {
+            if(state.contains(i.first)) {
+                state.insert_or_assign(i.first, i.second);
+            }
+        }
     } catch(...) {
         // Failed to parse the incoming state, or the state we did parse was not actually
         // an object type. How you handle it is up to you, here we just ignore it


### PR DESCRIPTION
Better handle state variables on restore, namely: 
- allowing for new properties to be propagated from manifest.json and not overwritten when state is restored
- only restore variables which are defined in manifest.json, which effectively prunes invalid data from the saved state