### PR TITLE
Dispatch console log messages to an editor, if one is active.

### DIFF
--- a/dsp/main.js
+++ b/dsp/main.js
@@ -31,7 +31,7 @@ function shouldRender(prevState, nextState) {
 // on the result of our `shouldRender` check.
 globalThis.__receiveStateChange__ = (serializedState) => {
   const state = JSON.parse(serializedState);
-
+  console.log(state);
   if (shouldRender(prevState, state)) {
     let stats = core.render(...srvb({
       key: 'srvb',

--- a/dsp/main.js
+++ b/dsp/main.js
@@ -31,7 +31,6 @@ function shouldRender(prevState, nextState) {
 // on the result of our `shouldRender` check.
 globalThis.__receiveStateChange__ = (serializedState) => {
   const state = JSON.parse(serializedState);
-  console.log(state);
   if (shouldRender(prevState, state)) {
     let stats = core.render(...srvb({
       key: 'srvb',

--- a/native/PluginProcessor.cpp
+++ b/native/PluginProcessor.cpp
@@ -262,9 +262,23 @@ void EffectsPluginProcessor::initJavaScriptEngine()
         return choc::value::Value();
     });
 
-    jsContext.registerFunction("__log__", [](choc::javascript::ArgumentList args) {
+    jsContext.registerFunction("__log__", [&](choc::javascript::ArgumentList args) {
+
+        const auto* kDispatchScript = R"script(
+(function() {
+  console.log(%);
+  return true;
+})();
+)script";
+
         for (size_t i = 0; i < args.numArgs; ++i) {
             DBG(choc::json::toString(*args[i], true));
+
+            // Dispatch to the UI if it's available
+            if (auto* editor = static_cast<WebViewEditor*>(getActiveEditor())) {
+                auto expr = juce::String(kDispatchScript).replace("%", elem::js::serialize(elem::js::serialize(choc::json::toString(*args[i], false)))).toStdString();
+                editor->getWebViewPtr()->evaluateJavascript(expr);
+            }
         }
 
         return choc::value::Value();

--- a/native/PluginProcessor.cpp
+++ b/native/PluginProcessor.cpp
@@ -262,8 +262,7 @@ void EffectsPluginProcessor::initJavaScriptEngine()
         return choc::value::Value();
     });
 
-    jsContext.registerFunction("__log__", [&](choc::javascript::ArgumentList args) {
-
+    jsContext.registerFunction("__log__", [this](choc::javascript::ArgumentList args) {
         const auto* kDispatchScript = R"script(
 (function() {
   console.log(%);

--- a/native/PluginProcessor.cpp
+++ b/native/PluginProcessor.cpp
@@ -271,8 +271,6 @@ void EffectsPluginProcessor::initJavaScriptEngine()
 )script";
 
         for (size_t i = 0; i < args.numArgs; ++i) {
-            DBG(choc::json::toString(*args[i], true));
-
             // Dispatch to the UI if it's available
             if (auto* editor = static_cast<WebViewEditor*>(getActiveEditor())) {
                 auto expr = juce::String(kDispatchScript).replace("%", elem::js::serialize(elem::js::serialize(choc::json::toString(*args[i], false)))).toStdString();

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -25,13 +25,15 @@ function requestParamValueUpdate(paramId, value) {
   }
 }
 
-import.meta.hot.on('reload-dsp', () => {
-  console.log('Sending reload dsp message');
+if (process.env.NODE_ENV !== 'production') {
+  import.meta.hot.on('reload-dsp', () => {
+    console.log('Sending reload dsp message');
 
-  if (typeof globalThis.__postNativeMessage__ === 'function') {
-    globalThis.__postNativeMessage__('reload');
-  }
-});
+    if (typeof globalThis.__postNativeMessage__ === 'function') {
+      globalThis.__postNativeMessage__('reload');
+    }
+  });
+}
 
 globalThis.__receiveStateChange__ = function(state) {
   store.setState(JSON.parse(state));


### PR DESCRIPTION
Using `choc::json::toString` on the messages; maybe there is a better way for converting the `choc::value::Value`s?

Added one `console.log` statement in `dsp/main.js` to easily verify the log message dispatches, by e.g. turning the knobs:

<img width="770" alt="Screenshot 2023-12-10 at 13 19 28" src="https://github.com/elemaudio/srvb/assets/183042/46d12416-0bb6-4552-ad7c-2c2bb25caa50">
